### PR TITLE
Add ocaml implementation

### DIFF
--- a/compile-all.sh
+++ b/compile-all.sh
@@ -2,6 +2,7 @@
 
 nim c --noLinking -d:release --parallelBuild:1 hello.nim && \
     zig build -Drelease-fast=true && \
+    make -C ocaml &&
     tup upd
 
 

--- a/ocaml/Makefile
+++ b/ocaml/Makefile
@@ -1,0 +1,3 @@
+all:
+	ocamlopt -o test.nat ../newplus/plus.o mlplus.c plus_ml.ml
+	ocamlc -o test.bc -custom ../newplus/plus.o mlplus.c plus_ml.ml

--- a/ocaml/mlplus.c
+++ b/ocaml/mlplus.c
@@ -1,0 +1,23 @@
+#include <caml/mlvalues.h>
+#include <caml/alloc.h>
+#include "../newplus/plus.h"
+
+CAMLprim value ml_plusone(value x)
+{
+  return Val_long(plusone(Long_val(x)));
+}
+
+CAMLprim intnat ml_plusone_untagged(intnat x)
+{
+  return plusone(x);
+}
+
+CAMLprim value ml_plusone_bc(value x)
+{
+  return caml_copy_int32(plusone(Int32_val(x)));
+}
+
+CAMLprim value ml_current_timestamp(value unit)
+{
+  return Val_long(current_timestamp());
+}

--- a/ocaml/plus_ml.ml
+++ b/ocaml/plus_ml.ml
@@ -1,0 +1,97 @@
+external current_timestamp : unit -> int = "ml_current_timestamp"
+
+external plusone_32_noalloc : (int32 [@unboxed]) -> (int32 [@unboxed]) =
+  "ml_plusone_bc" "plusone" [@@noalloc]
+
+external plusone_32_alloc : (int32 [@unboxed]) -> (int32 [@unboxed]) =
+  "ml_plusone_bc" "plusone"
+
+external plusone_32_boxed : int32 -> int32 = "ml_plusone_bc"
+
+external plusone_int_noalloc : int -> int = "ml_plusone" [@@noalloc]
+
+external plusone_int_alloc : int -> int = "ml_plusone"
+
+external plusone_int_untagged : (int [@untagged]) -> (int [@untagged]) =
+  "ml_plusone" "ml_plusone_untagged" [@@noalloc]
+
+let backend =
+  match Sys.backend_type with
+  | Sys.Native -> "native"
+  | Sys.Bytecode -> "bytecode"
+  | Sys.Other x -> x
+
+let run_32_noalloc limit =
+  let limit = Int32.of_int limit in
+  let start_at = current_timestamp () in
+  let x = ref Int32.zero in
+  while !x < limit do
+    x := plusone_32_noalloc !x
+  done;
+  let finish_at = current_timestamp () in
+  prerr_endline ("ocaml(int32,noalloc," ^ backend ^ ") = " ^ string_of_int (finish_at - start_at))
+
+let run_32_alloc limit =
+  let limit = Int32.of_int limit in
+  let start_at = current_timestamp () in
+  let x = ref Int32.zero in
+  while !x < limit do
+    x := plusone_32_alloc !x
+  done;
+  let finish_at = current_timestamp () in
+  prerr_endline ("ocaml(int32,alloc," ^ backend ^ ") = " ^ string_of_int (finish_at - start_at))
+
+let run_32_boxed limit =
+  let limit = Int32.of_int limit in
+  let start_at = current_timestamp () in
+  let x = ref Int32.zero in
+  while !x < limit do
+    x := plusone_32_boxed !x
+  done;
+  let finish_at = current_timestamp () in
+  prerr_endline ("ocaml(int32,boxed," ^ backend ^ ") = " ^ string_of_int (finish_at - start_at))
+
+let run_int_noalloc limit =
+  let start_at = current_timestamp () in
+  let x = ref 0 in
+  while !x < limit do
+    x := plusone_int_noalloc !x
+  done;
+  let finish_at = current_timestamp () in
+  prerr_endline ("ocaml(int,noalloc," ^ backend ^ ") = " ^ string_of_int (finish_at - start_at))
+
+let run_int_alloc limit =
+  let start_at = current_timestamp () in
+  let x = ref 0 in
+  while !x < limit do
+    x := plusone_int_alloc !x
+  done;
+  let finish_at = current_timestamp () in
+  prerr_endline ("ocaml(int,alloc," ^ backend ^ ") = " ^ string_of_int (finish_at - start_at))
+
+let run_int_untagged limit =
+  let start_at = current_timestamp () in
+  let x = ref 0 in
+  while !x < limit do
+    x := plusone_int_untagged !x
+  done;
+  let finish_at = current_timestamp () in
+  prerr_endline ("ocaml(int,untagged," ^ backend ^ ") = " ^ string_of_int (finish_at - start_at))
+
+let run_int_alloc limit =
+  let start_at = current_timestamp () in
+  let x = ref 0 in
+  while !x < limit do
+    x := plusone_int_alloc !x
+  done;
+  let finish_at = current_timestamp () in
+  prerr_endline ("ocaml(int,alloc," ^ backend ^ ") = " ^ string_of_int (finish_at - start_at))
+
+let () =
+  let limit = int_of_string Sys.argv.(1) in
+  run_int_noalloc limit;
+  run_int_alloc limit;
+  run_int_untagged limit;
+  run_32_noalloc limit;
+  run_32_alloc limit;
+  run_32_boxed limit;

--- a/run-all.sh
+++ b/run-all.sh
@@ -43,6 +43,14 @@ echo "\nrust:"
 ./rust_hello $@ && \
 ./rust_hello $@
 
+echo "\nocamlopt:"
+./ocaml/test.nat $@ && \
+./ocaml/test.nat $@
+
+echo "\nocamlc:"
+./ocaml/test.bc $@ && \
+./ocaml/test.bc $@
+
 echo "\nd:"
 ./d_hello $@ && \
 ./d_hello $@


### PR DESCRIPTION
This implementation is a bit different from the other ones as it test various features of the OCaml FFI. It it works with OCaml >= 4.03.0 and needs ocamlopt and ocamlc compilers.

First it tests the native and bytecode implementation (native generates binary code for the host platform, bytecode is interpreted).

Then the compiler is notified or not of whether the C code will allocate OCaml memory. With `noalloc`, compiler knows that `plusone` is not going to affect OCaml heap and can directly uses C ABI. Otherwise it has to be conservative and save the state of the memory allocator before switching to C.

Then it tests various representations of integers.

With int32, values are represented has 32 bit integers; this match the C ABI (`int` are 32 bits) on most platforms, in that case this is the fastest path, otherwise it is unsafe. To be OCaml friendly / more portable, the C prototype should use `int32_t` or `int64_t` to avoid divergences between platforms.

int32 boxed forces each integer to be boxed. This is similar to using Java `Integer` class which allocates a new instance for each value. Thus, this path allocates a few gigabytes of memory in the benchmark.

With int, the native integer representation of OCaml is used. int untagged indicates that C code exports normal integers that have the same size as a pointer (named intnat in OCaml FFI, intptr_t in C standard).

Why so many complications? It is just to show that the FFI is very flexible to adapt to most situations, including when very low overhead is required.

Observations:
- with the int32 native code path, the C function is directly called; on my computer it is the fastest of all benchmarks, most of the time is spent handling function call
- most other tests add a trampoline functions (when the OCaml compiler can't use the C ABI directly), this function adapts the OCaml ABI and C ABI, and what is measure is the call of one indirection, not the actual logic
- only the int32 boxed case allocates a lot of memory (8 gigabytes for 1000000000 run), yet it is still competitive with other candidates
- the bytecode is here to show which optimizations are lost when switching to an interpreter; it is much slower but still reasonably efficient