### PR TITLE
docs: fix simple typo, caculate -> calculate

### DIFF
--- a/jhello/jhello_Hello.c
+++ b/jhello/jhello_Hello.c
@@ -28,7 +28,7 @@ JNIEXPORT jlong JNICALL Java_jhello_Hello_current_1timestamp
     return current_timestamp();
     /*struct timeval te; 
     gettimeofday(&te, NULL); // get current time
-    jlong milliseconds = te.tv_sec*1000LL + te.tv_usec/1000; // caculate milliseconds
+    jlong milliseconds = te.tv_sec*1000LL + te.tv_usec/1000; // calculate milliseconds
     
     return milliseconds;*/
 }

--- a/newplus/plus.c
+++ b/newplus/plus.c
@@ -16,7 +16,7 @@ long long current_timestamp()
 {
     struct timeval te; 
     gettimeofday(&te, NULL); // get current time
-    long long milliseconds = te.tv_sec*1000LL + te.tv_usec/1000; // caculate milliseconds
+    long long milliseconds = te.tv_sec*1000LL + te.tv_usec/1000; // calculate milliseconds
     
     return milliseconds;
 }


### PR DESCRIPTION
There is a small typo in jhello/jhello_Hello.c, newplus/plus.c.

Should read `calculate` rather than `caculate`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md