### PR TITLE
Benchmarks and source for V

### DIFF
--- a/hello.v
+++ b/hello.v
@@ -1,0 +1,33 @@
+import os
+import strconv
+
+#flag -I.
+#include "newplus/plus.c"
+
+fn C.plusone(int) int
+fn C.current_timestamp(int) i64
+
+fn run(count int) i64 {
+  mut x := 0
+  start := C.current_timestamp()
+
+  for x < count {
+    x = C.plusone(x)
+  }
+
+  return C.current_timestamp() - start
+}
+
+fn main() {
+  if os.args.len == 0 {
+    println("First arg (0 - 2000000000) is required.")
+    return
+  }
+
+  count := strconv.atoi(os.args[1]) or {
+    println("Must be a positive number not exceeding 2 billion.")
+    return
+  }
+
+  println(run(count))
+}

--- a/run-all.sh
+++ b/run-all.sh
@@ -99,3 +99,7 @@ elixir -r hello.ex -e "S.start" $@
 echo "\njulia:"
 julia hello.jl $@ && \
 julia hello.jl $@
+
+echo "\nV:"
+v run hello.v $@ && \
+v run hello.v $@


### PR DESCRIPTION
I was recently playing around with V (https://vlang.io) and put this together to play around with the ffi implementation. V is still a pre v1 language, but it has some really interesting features. I had a hard time getting tup to work locally so my V file simply includes the C source file. I believe this should be the same as including the header file and compiling with the shared library, let me know what you think though.

### Results

```
~/code/ffi-overhead $ ./run-all.sh 500000000
The results are elapsed time in milliseconds
============================================

V:
1780
1753
```

### Version

```
 ~/code/ffi-overhead $  v version
V 0.2.1 bbac95a
```

### Hardware

```
~/code/ffi-overhead $ system_profiler SPHardwareDataType
Hardware:

    Hardware Overview:

      Model Name: MacBook Pro
      Model Identifier: MacBookPro13,3
      Processor Name: Intel Core i7
      Processor Speed: 2.6 GHz
      Number of Processors: 1
      Total Number of Cores: 4
      L2 Cache (per Core): 256 KB
      L3 Cache: 6 MB
      Hyper-Threading Technology: Enabled
      Memory: 16 GB
```