### PR TITLE
Update to latest zig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@
 *.hi
 
 .tup
+
+zig-out

--- a/build.zig
+++ b/build.zig
@@ -1,17 +1,19 @@
 const Builder = @import("std").build.Builder;
 
-pub fn build(b: &Builder) void {
+pub fn build(b: *Builder) void {
     const mode = b.standardReleaseOptions();
     const exe = b.addExecutable("zig_hello", "hello.zig");
     exe.setBuildMode(mode);
     exe.addIncludeDir(".");
-    exe.addLibPath("newplus");
-    exe.linkSystemLibrary("c");
-    exe.linkSystemLibrary("newplus");
-    exe.setOutputPath("zig_hello");
-    
-    b.addRPath("$ORIGIN/newplus");
-    
+    exe.linkLibC();
+    exe.addIncludeDir(b.pathFromRoot("."));
+    exe.addCSourceFiles(&.{
+        b.pathFromRoot("newplus/plus.c"),
+    }, &.{});
+    exe.setOutputDir("zig_hello");
+
+    exe.addRPath("$ORIGIN/newplus");
+
     b.default_step.dependOn(&exe.step);
     b.installArtifact(exe);
 }

--- a/hello.zig
+++ b/hello.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 const os = std.os;
 const io = std.io;
-//const allocator = std.debug.global_allocator;
 const allocator = std.heap.c_allocator;
 const c = @cImport({
     // See https://github.com/zig-lang/zig/issues/515
@@ -10,37 +9,34 @@ const c = @cImport({
     @cInclude("newplus/plus.h");
 });
 
-pub fn main() !void {
-    
-    var stdout_file = try io.getStdOut();
-    var stdout_file_stream = io.FileOutStream.init(&stdout_file);
-    const stdout = &stdout_file_stream.stream;
-    
-    const args = try os.argsAlloc(allocator);
-    defer os.argsFree(allocator, args);
-    
+pub fn main() anyerror!void {
+    var stdout_file = io.getStdOut();
+    const stdout = stdout_file;
+
+    const args = try std.process.argsAlloc(allocator);
+
     if (args.len == 1) {
-        try stdout.print("First arg (0 - 2000000000) is required.\n");
+        try stdout.writeAll("First arg (0 - 2000000000) is required.\n");
         return;
     }
-    
+
     const count = try std.fmt.parseInt(i32, args[1], 10);
     if (count <= 0 or count > 2000000000) {
-        try stdout.print("Must be a positive number not exceeding 2 billion.\n");
+        try stdout.writeAll("Must be a positive number not exceeding 2 billion.\n");
         return;
     }
-    
+
     run(count);
 }
 
 fn run(count: i32) void {
     const start = c.current_timestamp();
-    
+
     var x: i32 = 0;
     while (x < count) {
         x = c.plusone(x);
     }
-    
+
     const elapsed = c.current_timestamp() - start;
-    _ = c.printf(c"%lld\n", elapsed);
+    _ = c.printf("%lld\n", elapsed);
 }

--- a/run-all.sh
+++ b/run-all.sh
@@ -32,8 +32,8 @@ echo "\ncpp:"
 ./cpp_hello $@
 
 echo "\nzig:"
-./zig_hello $@ && \
-./zig_hello $@
+./zig_hello/zig_hello $@ && \
+./zig_hello/zig_hello $@
 
 echo "\nnim:"
 ./nim_hello $@ && \


### PR DESCRIPTION
The version of zig listed in the readme is 3-ish years old

I was curious what the numbers look like now so I updated it


./a.out is the the c implementation compiled with `clang hello.c  newplus/plus.c --std=c17 -O2` on macOS
```
❯ hyperfine "./zig_hello/zig_hello 500000000" "./a.out 500000000"
Benchmark #1: ./zig_hello/zig_hello 500000000
  Time (mean ± σ):     446.2 ms ±   6.8 ms    [User: 443.6 ms, System: 0.9 ms]
  Range (min … max):   437.8 ms … 458.9 ms    10 runs

Benchmark #2: ./a.out 500000000
  Time (mean ± σ):     447.5 ms ±   5.5 ms    [User: 445.0 ms, System: 0.8 ms]
  Range (min … max):   440.4 ms … 456.8 ms    10 runs

Summary
  './zig_hello/zig_hello 500000000' ran
    1.00 ± 0.02 times faster than './a.out 500000000'
```