### PR TITLE
guile: dynamic ffi (slow)

### DIFF
--- a/Tupfile
+++ b/Tupfile
@@ -54,6 +54,9 @@ NODE_CXX_FLAGS = $(CXXFLAGS) -fno-exceptions
 
 : d_ldc2/*.o | $(DEPS) |> ldc2 -betterC %f -of%o -L-Lnewplus -L-lnewplus -L-rpath=$(RPATH_NEWPLUS) -O -release |> d_ldc2_hello
 
+# guile
+: guile/hello.scm |> guild compile -o %o %f |> guile/hello.go
+
 # haskell
 : hello.hs | $(DEPS) |> /opt/ghc/bin/ghc -O2 -Lnewplus -lnewplus -optl-Wl,-rpath,$(RPATH_NEWPLUS) -o ghc_hello %f |> ghc_hello hello.hi hello.o
 

--- a/guile/hello.scm
+++ b/guile/hello.scm
@@ -1,0 +1,49 @@
+(define-module (hello)
+  #:use-module (srfi srfi-19)
+  #:use-module (system foreign)
+  #:export (main))
+;;
+;; Using https://hyper.dev/blog/2018/gnu-guile-ffi/:
+;;
+;;   Copyright © Amirouche
+;;   Amazigh BOUBEKKI, and contributors (2012-2022).
+;;
+;;   Permission is hereby granted, free of charge, to any person obtaining a copy
+;;   of this software and associated documentation files (the "Software"), to
+;;   deal in the Software without restriction, including without limitation the
+;;   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+;;   sell copies of the Software, and to permit persons to whom the Software is
+;;   furnished to do so, subject to the following conditions:
+;;
+;;   The above copyright notice and this permission notice shall be included in
+;;   all copies or substantial portions of the Software.
+;;
+;;   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+;;   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+;;   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+;;   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+;;   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+;;   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+;;   IN THE SOFTWARE.
+;;
+(define* (dynamic-link* #:optional library-name)
+	 (let ((shared-object (if library-name (dynamic-link library-name)
+				(dynamic-link))))
+	   (lambda (return-value function-name . arguments)
+	     (let ((function (dynamic-func function-name shared-object)))
+	       (pointer->procedure return-value function arguments)))))
+
+(define FFI (dynamic-link* "./newplus/libnewplus.so"))
+(define plusone (FFI int "plusone" int))
+
+(define* (hello #:optional (count 2000000000))
+	 (let ((start (current-time)))
+	   (let loop ((x 0)
+		      (count count))
+	     (if (< x count)
+	       (loop (plusone x) count)))
+	   (time-nanosecond (time-difference (current-time) start))))
+
+(define* (main #:rest args)
+	 (map display
+	      (list (apply hello args) "\n")))

--- a/run-all.sh
+++ b/run-all.sh
@@ -55,6 +55,10 @@ echo "\nd ldc2:"
 ./d_ldc2_hello $@ && \
 ./d_ldc2_hello $@
 
+echo "\nguile:"
+guile -C ./guile -c '(use-modules (hello))(main '"$@"')' && \
+guile -C ./guile -c '(use-modules (hello))(main '"$@"')'
+
 echo "\nhaskell:"
 ./ghc_hello $@ && \
 ./ghc_hello $@


### PR DESCRIPTION
Hi! This pull isn't merge-worthy quite yet, and I don't know that I'll come back to it tomorrow, but I wanted to be sure to leave what I have in case anyone else has any insights.

I first implemented this as shown on the guile_concise branch, and then again with a dedicated extension and the extra boilerplate needed to compile it, in the naive hope that would speed it up, but I just don't know what I'm doing :p

Here are the results I get (with the tool-chains that I bothered to setup, am on GuixSD):

```
The results are elapsed time in milliseconds
============================================
luajit:
2283
2260
c:
3117
3093
cpp:
3092
3155
guile:
564329000 # ⎤ concise branch
464285000 # ⎦
354308000 # ⎤ extension branch
562453000 # ⎦
haskell:
3179
3141
node:
18180
17727
go:
76953
76586
julia:
4013
2239
```

Yeah, yikes, that can't be right. Maybe I'm measuring nanoseconds wrong? It went through a few drafts, but was always putting out a few figures more than I'd like. I tried profiling it with [`statprof`](https://www.gnu.org/software/guile/manual/html_node/Statprof.html), but it's all too far down in `plusone`. I could try enabling optimizations, but am still leaning towards some confusion of measurements, am tired.

What's missing:
* Why so slow???
* Readme updates
* Testing with upstream's configuration
* Guile auto-compiles `.scm` files on first-run, so it probably doesn't even need handled in the Tupfile for the concise branch.